### PR TITLE
Added json results

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -6,6 +6,8 @@ language: deu
 # Receipts should be simple text files
 receipts_path: "data/txt"
 
+results_as_json: true
+
 # Market names roughly ordered by likelihood.
 # Can contain market locations for fuzzy parsing
 markets:

--- a/receipt_parser_core/parse.py
+++ b/receipt_parser_core/parse.py
@@ -18,6 +18,7 @@
 import os
 import time
 from collections import defaultdict
+import json
 
 from terminaltables import SingleTable
 
@@ -109,6 +110,9 @@ def ocr_receipts(config, receipt_files):
         ['Path', 'Market', "Date", "Items", "SUM"],
     ]
 
+    if config.results_as_json:
+        results_to_json(config, receipt_files)
+
     for receipt_path in receipt_files:
         with open(receipt_path, encoding="utf8", errors='ignore') as receipt:
             receipt = Receipt(config, receipt.readlines())
@@ -134,3 +138,12 @@ def ocr_receipts(config, receipt_files):
     print(table.table)
 
     return stats
+
+
+def results_to_json(config, receipt_files):
+    for receipt_path in receipt_files:
+        with open(receipt_path, encoding="utf8", errors='ignore') as receipt:
+            receipt = Receipt(config, receipt.readlines())
+            out = open(receipt_path + ".json", "w")
+            out.write(receipt.to_json())
+            out.close()

--- a/receipt_parser_core/receipt.py
+++ b/receipt_parser_core/receipt.py
@@ -20,6 +20,7 @@ from difflib import get_close_matches
 
 import dateutil.parser
 from collections import namedtuple
+import json
 
 
 class Receipt(object):
@@ -163,3 +164,18 @@ class Receipt(object):
                 sum_float = re.search(self.config.sum_format, sum_line)
                 if sum_float:
                     return sum_float.group(0)
+
+
+    def to_json(self):
+        """
+        :return: json
+            Convert Receipt object to json
+        """
+        object_data = {
+            "market": self.market,
+            "date": self.date,
+            "sum": self.sum,
+            "items": self.items,
+            "lines": self.lines
+        }
+        return json.dumps(object_data)


### PR DESCRIPTION
I propose the addition of a json formatted file to represent the Receipt data, which is generated if the corresponding option is enabled in the config file. This would allow an easier processing of the data produced by the parser.

I am not sure it is implemented in the best way possible, so I am fully open to recommendations and improvements.