### PR TITLE
allow custom (per-market) regex config

### DIFF
--- a/receipt_parser_core/objectview.py
+++ b/receipt_parser_core/objectview.py
@@ -17,7 +17,7 @@
 
 
 class ObjectView(object):
-    """ View objects as dicts """
+    """View objects as dicts"""
 
     def __init__(self, d):
         """
@@ -26,3 +26,21 @@ class ObjectView(object):
         """
 
         self.__dict__ = d
+
+    def __getitem__(self, item):
+        """
+        Use ObjectView like dict
+        :param item: str | int
+            Object value
+        """
+        return self.__dict__[item]
+
+    def get_config(self, key, market):
+        """
+        Get custom market config if available, otherwise return default config.
+        :param key: str
+        :param market: str
+            Object value
+        """
+        custom_config_key = f"{key}_{market.lower()}"
+        return self.__dict__.get(custom_config_key, self.__dict__[key])

--- a/receipt_parser_core/objectview.py
+++ b/receipt_parser_core/objectview.py
@@ -17,7 +17,7 @@
 
 
 class ObjectView(object):
-    """View objects as dicts"""
+    """ View objects as dicts """
 
     def __init__(self, d):
         """

--- a/receipt_parser_core/receipt.py
+++ b/receipt_parser_core/receipt.py
@@ -24,7 +24,7 @@ import dateutil.parser
 
 
 class Receipt(object):
-    """Market receipt to be parsed"""
+    """ Market receipt to be parsed """
 
     def __init__(self, config, raw):
         """
@@ -52,7 +52,9 @@ class Receipt(object):
 
         """
 
-        self.lines = [line.lower() for line in self.lines if line.strip()]
+        self.lines = [
+            line.lower() for line in self.lines if line.strip()
+        ]
 
     def parse(self):
         """
@@ -126,13 +128,13 @@ class Receipt(object):
                         return items
 
             match = re.search(item_format, line)
-            if hasattr(match, "group"):
+            if hasattr(match, 'group'):
                 article_name = match.group(1)
 
                 if match.group(2) == "-":
                     article_sum = "-" + match.group(3).replace(",", ".")
                 else:
-                    article_sum = match.group(3)
+                    article_sum = match.group(3).replace(",", ".")
             else:
                 continue
 
@@ -187,7 +189,7 @@ class Receipt(object):
             "date": self.date,
             "sum": self.sum,
             "items": self.items,
-            "lines": self.lines,
+            "lines": self.lines
         }
 
         return json.dumps(object_data)

--- a/receipt_parser_core/receipt.py
+++ b/receipt_parser_core/receipt.py
@@ -110,10 +110,6 @@ class Receipt(object):
         stop_words = self.config.get_config("sum_keys", self.market)
         item_format = self.config.get_config("item_format", self.market)
 
-        print(item_format)
-        print(ignored_words)
-        print(stop_words)
-
         for line in self.lines:
             parse_stop = None
             for ignore_word in ignored_words:
@@ -136,7 +132,7 @@ class Receipt(object):
                 if match.group(2) == "-":
                     article_sum = "-" + match.group(3).replace(",", ".")
                 else:
-                    article_sum = match.group(3).replace(",", ".")
+                    article_sum = match.group(3)
             else:
                 continue
 

--- a/receipt_parser_core/receipt.py
+++ b/receipt_parser_core/receipt.py
@@ -24,7 +24,7 @@ import dateutil.parser
 
 
 class Receipt(object):
-    """ Market receipt to be parsed """
+    """Market receipt to be parsed"""
 
     def __init__(self, config, raw):
         """
@@ -52,9 +52,7 @@ class Receipt(object):
 
         """
 
-        self.lines = [
-            line.lower() for line in self.lines if line.strip()
-        ]
+        self.lines = [line.lower() for line in self.lines if line.strip()]
 
     def parse(self):
         """
@@ -108,13 +106,13 @@ class Receipt(object):
         items = []
         item = namedtuple("item", ("article", "sum"))
 
-        ignored_words = self.config.ignore_keys
-        stop_words = self.config.sum_keys
+        ignored_words = self.config.get_config("ignore_keys", self.market)
+        stop_words = self.config.get_config("sum_keys", self.market)
+        item_format = self.config.get_config("item_format", self.market)
 
-        if self.market == "Metro":
-            item_format = self.config.item_format_metro
-        else:
-            item_format = self.config.item_format
+        print(item_format)
+        print(ignored_words)
+        print(stop_words)
 
         for line in self.lines:
             parse_stop = None
@@ -132,7 +130,7 @@ class Receipt(object):
                         return items
 
             match = re.search(item_format, line)
-            if hasattr(match, 'group'):
+            if hasattr(match, "group"):
                 article_name = match.group(1)
 
                 if match.group(2) == "-":
@@ -193,7 +191,7 @@ class Receipt(object):
             "date": self.date,
             "sum": self.sum,
             "items": self.items,
-            "lines": self.lines
+            "lines": self.lines,
         }
 
         return json.dumps(object_data)


### PR DESCRIPTION
Proposed change allows the user to provide following the `config.yml`
```
language: deu

receipts_path: "data/txt"

results_as_json: false

markets:
  Colruyt:
     - colruyt
     - Colruyt
  Migros:
     - genossenschaft migros
  Metro:
     - vetro
     - metro

sum_keys:
  - summe

sum_keys_metro:
  - something
  - sumthing

ignore_keys:
  - mwst

ignore_keys_migros:
  - something something

sum_format: '\d+(\.\s?|,\s?|[^a-zA-Z\d])\d{2}'
sum_format_colruyt: '[0-9a-f]*'

item_format: '([a-zA-Z].+)\s(-|)((\d|\d{2}),(\d{2}|\d{3}))\s'
item_format_metro: '[0-9]\s(.*?)\d.()((\d|\d{2})(\,|\.)\d{1,2})\s([A|a]|[B|b])'
item_format_migros: '[0-9a-f]*'

date_format: '((\d{2}\.\d{2}\.\d{2,4})|(\d{2,4}\/\d{2}\/\d{2})|(\d{2}\/\d{2}\/\d{4}))'
```
meaning, the script will respect custom, per-market configs.
